### PR TITLE
Add method to stack cutouts

### DIFF
--- a/cutout.py
+++ b/cutout.py
@@ -161,9 +161,15 @@ class CutoutProducer:
         if not hasattr(self, "coadd_ids"):
             self.get_coadd_ids()
 
-        image_array = np.empty((len(self.coadd_ids), len(bands), self.cutout_size, self.cutout_size), dtype=np.double)
+        image_array = np.empty((len(bands), len(self.coadd_ids), self.cutout_size, self.cutout_size), dtype=np.double)
 
-        raise NotImplementedError("Someone needs to do this")
+        for i, band in enumerate(bands):
+            image, wcs = self.read_tile_image(band)
+            cutouts = self.cutout_objects(image, wcs)
+            image_array[i] = cutouts
+
+        image_array = np.swapaxes(image_array, 0, 1)
+
         return image_array
 
     def produce_cutout_file(self, image_array, out_dir=''):


### PR DESCRIPTION
Adding a method to stack the cutouts for each band into one array. The process is:

1. For each band, pull cutouts of all objects into an array (resulting in one array per band)
2. Stack these individual arrays together and then reshape to have the desired dimensions: (num_cutouts, num_bands, cutout_width, cutout_height)