### PR TITLE
Div by zero

### DIFF
--- a/cutout.py
+++ b/cutout.py
@@ -188,6 +188,7 @@ class CutoutProducer:
         cutouts = np.empty((len(self.coadd_ids), self.cutout_size, self.cutout_size), dtype=np.double)
         for i, (x, y) in enumerate(zip(object_x, object_y)):
             cutouts[i] = self.single_cutout(image, (x, y), self.cutout_size)
+
         return cutouts
 
     def single_cutout(self, image, center, width=None):
@@ -237,11 +238,12 @@ class CutoutProducer:
         psf_cutouts = np.empty((len(self.coadd_ids), self.psf_cutout_size, self.psf_cutout_size), dtype=np.double)
 
         for i, (x, y) in enumerate(zip(object_x, object_y)):
-            pos = galsim.PositionD(x,y)
+            pos = galsim.PositionI(x,y) 
             psfimg = psf.getPSFArray(pos)
             center = (psfimg.shape[0] // 2, psfimg.shape[1] // 2)
             psfimg = self.single_cutout(psfimg, center, self.psf_cutout_size)
-            psf_cutouts[1] = psfimg
+            psf_cutouts[i] = psfimg
+
         return psf_cutouts
 
     def combine_bands(self):
@@ -290,14 +292,6 @@ class CutoutProducer:
         """
         original_min = np.min(arr, axis=(-1, -2))
         shifted_max = np.max(arr - original_min[:,:,np.newaxis,np.newaxis], axis=(-1, -2))
-
-        #test for zeros
-        for i in range(len(arr)):
-            for j in range(len(arr[0])):
-                #if shifted_max[i, j] != 0:
-                #    print(i, j)
-                if arr[i,j].max() == arr[i,j].min():
-                    print(i, j, arr[i,j].max())
 
         int_arr = np.rint(
             (arr - original_min[:,:,np.newaxis,np.newaxis]) / 

--- a/cutout.py
+++ b/cutout.py
@@ -178,9 +178,10 @@ class CutoutProducer:
         object_x, object_y = self.get_object_xy(wcs)
 
         # Shout if any object is outside of tile
-        if not np.all((0 < object_x) & (object_x < image.shape[0])
-                    & (0 < object_y) & (object_y < image.shape[1])):
+        if not np.all((0 < object_x) & (object_x < image.shape[1])
+                      & (0 < object_y) & (object_y < image.shape[0])):
             raise ValueError('Some objects centered out of tile')
+
 
         # FIXME: If an object is too close to a tile edge, single_cutout will
         # return a misshapen cutout, and this will throw an error
@@ -205,10 +206,10 @@ class CutoutProducer:
         if width > min(image.shape):
             raise ValueError('Requested cutout is larger than image size')
         if (width % 2) == 0:
-            return image[x - width//2: x + width//2,
-                         y - width//2: y + width//2]
-        return image[x - width//2: x + width//2 + 1,
-                     y - width//2: y + width//2 + 1]
+            return image[y - width//2: y + width//2,
+                         x - width//2: x + width//2]
+        return image[y - width//2: y + width//2 + 1,
+                     x - width//2: x + width//2 + 1]
 
     def read_psf(self, band):
         """
@@ -289,6 +290,15 @@ class CutoutProducer:
         """
         original_min = np.min(arr, axis=(-1, -2))
         shifted_max = np.max(arr - original_min[:,:,np.newaxis,np.newaxis], axis=(-1, -2))
+
+        #test for zeros
+        for i in range(len(arr)):
+            for j in range(len(arr[0])):
+                #if shifted_max[i, j] != 0:
+                #    print(i, j)
+                if arr[i,j].max() == arr[i,j].min():
+                    print(i, j, arr[i,j].max())
+
         int_arr = np.rint(
             (arr - original_min[:,:,np.newaxis,np.newaxis]) / 
             shifted_max[:,:,np.newaxis,np.newaxis] * 65535).astype(np.uint16) 

--- a/test/test_cutout.py
+++ b/test/test_cutout.py
@@ -130,10 +130,10 @@ class TestCutoutProducer(unittest.TestCase):
         self.assertEqual(np.shape(cutout)[1], width)
 
         # test pixel values
-        self.assertEqual(cutout[0][0], image[center[0] - width // 2][center[1] - width // 2])
-        self.assertEqual(cutout[0][-1], image[center[0] - width // 2][center[1] + width // 2])
-        self.assertEqual(cutout[-1][0], image[center[0] + width // 2][center[1] - width // 2])
-        self.assertEqual(cutout[-1][-1], image[center[0] + width // 2][center[1] + width // 2])
+        self.assertEqual(cutout[0][0], image[center[1] - width // 2][center[0] - width // 2])
+        self.assertEqual(cutout[0][-1], image[center[1] - width // 2][center[0] + width // 2])
+        self.assertEqual(cutout[-1][0], image[center[1] + width // 2][center[0] - width // 2])
+        self.assertEqual(cutout[-1][-1], image[center[1] + width // 2][center[0] + width // 2])
 
     def test_cutout_psfs(self):
         self.cutout_producer.get_coadd_ids()


### PR DESCRIPTION
#18 

The bug was that all psfs were being put at index 1 in the final array instead of at their specific index. Git blame points to @rmorgan10 . Nice going champ.