### PR TITLE
Adjusting the output formats

### DIFF
--- a/cutout.py
+++ b/cutout.py
@@ -322,8 +322,8 @@ class CutoutProducer:
         # Make the COADD_ID HDU
         if not hasattr(self, "coadd_ids"):
             self.get_coadd_ids()
-        col = fits.Column(name='COADD_OBJECT_ID', array=self.coadd_ids, format='J')
-        coadd_ids = fits.BinTableHDU.from_columns([col], name="CUTOUT_ID")
+        col = fits.Column(name='ID', array=self.coadd_ids, format='J')
+        coadd_ids = fits.BinTableHDU.from_columns([col], name="ID")
 
         # Make the IMAGE HDU
         image = fits.ImageHDU(image_array, name="IMAGE")

--- a/cutout.py
+++ b/cutout.py
@@ -167,8 +167,8 @@ class CutoutProducer:
                 [ (f"DCRPIX{i}",float) for i in [1,2]] + \
                 [ (f"CRPIX{i}", float) for i in [1,2]]  + \
                 [ (f"CRVAL{i}", float) for i in [1,2]]  + \
-                [ (f"CD{j}_{i}",float) for i in [1,2] for j in [1,2]]   + \
-                [ (f"PV{j}_{i}",float) for i in range(11) for j in [1,2]]
+                [ (f"CD{j}_{i}",float) for i in [1,2] for j in [1,2]] #  + \
+                #[ (f"PV{j}_{i}",float) for i in range(11) for j in [1,2]]
         DTYPES = [ (n, (d, len(self.bands))) for n, d in DTYPE]
 
         wcs_table = np.zeros(1, dtype=DTYPES)
@@ -390,7 +390,8 @@ if __name__ == "__main__":
     CUTOUT_SIZE = 45
     PSF_CUTOUT_SIZE = 25
     BANDS = "griz"
-    OUTDIR = "/data/des81.b/data/stronglens/Y6_CUTOUT_IMAGES/"
+    #OUTDIR = "/data/des81.b/data/stronglens/Y6_CUTOUT_IMAGES/"
+    OUTDIR = "/data/des81.b/data/stronglens/PRODUCTION/Y6_CUTOUT_IMAGES/full_tile_test/"
 
     # Make a CutoutProducer for the tile
     cutout_prod = CutoutProducer(tilename, CUTOUT_SIZE, PSF_CUTOUT_SIZE, bands=BANDS)

--- a/test/test_cutout.py
+++ b/test/test_cutout.py
@@ -187,26 +187,23 @@ class TestCutoutProducer(unittest.TestCase):
 
         # Verify existence of data products
         hdu = fits.open(outfile_name)
-        self.assertEqual(len(hdu), 8)
-
-        # check coadd ids
-        self.assertEqual(len(hdu[1].data), len(self.cutout_producer.coadd_ids))
-        np.testing.assert_array_equal(hdu[1].data.astype(int), self.cutout_producer.coadd_ids)
+        self.assertEqual(len(hdu), 4)
 
         # check image array
-        np.testing.assert_array_equal(np.shape(hdu[2].data), np.shape(image_array))
-        np.testing.assert_allclose(hdu[2].data, image_array)
+        np.testing.assert_array_equal(np.shape(hdu['IMAGE'].data), np.shape(image_array))
+        np.testing.assert_allclose(hdu['IMAGE'].data, image_array)
 
         # check psf array
-        np.testing.assert_array_equal(np.shape(hdu[3].data), np.shape(psf_array))
-        np.testing.assert_allclose(hdu[3].data, psf_array)
-        self.assertEqual(hdu[3].header['PSFSAMPg'], self.cutout_producer.psf_samp_g)
+        np.testing.assert_array_equal(np.shape(hdu['PSF'].data), np.shape(psf_array))
+        np.testing.assert_allclose(hdu['PSF'].data, psf_array)
+        self.assertEqual(hdu['PSF'].header['PSFSAMPg'], self.cutout_producer.psf_samp_g)
 
-        # check recovery arrays
-        np.testing.assert_allclose(hdu[4].data, img_min)
-        np.testing.assert_allclose(hdu[5].data, img_scale)
-        np.testing.assert_allclose(hdu[6].data, psf_min)
-        np.testing.assert_allclose(hdu[7].data, psf_scale)
+        # check info array
+        np.testing.assert_array_equal(hdu['INFO'].data['ID'], self.cutout_producer.coadd_ids.astype(str))  # Coadd IDs
+        np.testing.assert_allclose(hdu['INFO'].data['IMG_MIN'], img_min)      
+        np.testing.assert_allclose(hdu['INFO'].data['IMG_SCALE'], img_scale)
+        np.testing.assert_allclose(hdu['INFO'].data['PSF_MIN'], psf_min)
+        np.testing.assert_allclose(hdu['INFO'].data['PSF_SCALE'], psf_scale)
 
         hdu.close()
 


### PR DESCRIPTION
First commit addresses Issue #23 and changes both the TableHDU name and the name of the column containing the COADD_OBJECT_IDs to "ID". Tests pass, because neither "CUTOUT_ID" or "COADD_OBJECT_ID" were hard-coded into the tests.